### PR TITLE
Fix OST leaderboard header hidden text

### DIFF
--- a/LocalLeaderboard/UI/ViewControllers/LeaderboardView.cs
+++ b/LocalLeaderboard/UI/ViewControllers/LeaderboardView.cs
@@ -325,8 +325,8 @@ namespace LocalLeaderboard.UI.ViewControllers
         {
             base.DidDeactivate(removedFromHierarchy, screenSystemDisabling);
             if (!_plvc) return;
-            if (!_plvc.isActivated) return;
             _plvc.GetComponentInChildren<TextMeshProUGUI>().color = Color.white;
+            if (!_plvc.isActivated) return;
             page = 0;
             parserParams.EmitEvent("hideInfoModal");
             scoreInfoModal.parserParams.EmitEvent("hideScoreInfo");


### PR DESCRIPTION
This fixes this issue that was happening if you go from LocalLeaderboard to OST leaderboard:

![image](https://github.com/speecil/LocalLeaderboard-PC/assets/793322/f9888f69-208f-4046-b41d-cdee2c341ced)

Don't forget to bump the version in both manifest & assembly before uploading it again on Beatmods.